### PR TITLE
Documentation update for Sparkline Chart and Waffle Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ A string to put in front of the values. e.g. `$`.
 
 A string to put at the end of the values. e.g. `%`.
 
+## Options for specific charts
+
 ### Line Chart
 
 Name the X axis in the data sheet `x` for ordinal data or `date` for time based data. If it is time based data you *must* ensure it matches the [parseDateFormat](#parsedateformat) option so the chart builder knows how to interpret the dates correctly.

--- a/README.md
+++ b/README.md
@@ -465,6 +465,9 @@ A 10 x 10 square chart where each square represents approximately 1% of the data
 #### labelWidth & labelMargin
 > Set label width to the width of your longest label. Set a sensible margin between the labels and the chart. Defaults: `85px` & `6px`
 
+#### alignCenter
+> Default to `off`. If set to `on` the waffle chart will center aligned on Desktop and Fluid views.
+
 ### Sparkline chart
 
 Multiple small lines stacked against each other with minimum and maximum points marked and final data point marked. Minimum and maximum and final data values are also displayed.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ A string to put at the end of the values. e.g. `%`.
 
 ### Line Chart
 
-Name the X axis in the data sheet `x` for ordinal data or `date` for time based data. If it is time based data you *must* ensure it matches the[parseDateFormat](#parseDateFormat) option so the chart builder knows how to interpret the dates correctly.
+Name the X axis in the data sheet `x` for ordinal data or `date` for time based data. If it is time based data you *must* ensure it matches the [parseDateFormat](#parsedateformat) option so the chart builder knows how to interpret the dates correctly.
 
 #### ratio
 
@@ -510,7 +510,7 @@ Common issues
 
 If your data is displaying but not being plotted in the correct coordinates it is possible that you are either:
 
-1.	Using a date format different to the default (or the one specified by`parseDateFormat`). You can either update your dates in the data to use the default date format, or define a `parseDateFormat` that matches the date format you are using. See [parseDateFormat](#parseDateFormat) for more information.
+1.	Using a date format different to the default (or the one specified by`parseDateFormat`). You can either update your dates in the data to use the default date format, or define a `parseDateFormat` that matches the date format you are using. See [parseDateFormat](#parsedateformat) for more information.
 
 2.	The date cells in the Google Sheets are being formatted in the sheet itself. This means that what is presented in the sheet is a different format to the underlying data. In this case there are two options:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A fork of [NPR Visuals' dailygraphics project](https://github.com/nprapps/dailyg
 This project is used with the [Chart Builder](https://github.com/abcnews/chart-builder/) project to provide editors a web interface for creating new graphics.
 
 -	[Chart configuration options](#chart-configuration-options)
-
+	
 	-	[Common](#common)
 	-	[Line Chart](#line-chart)
 	-	[Bar Chart](#bar-chart)
@@ -20,6 +20,7 @@ This project is used with the [Chart Builder](https://github.com/abcnews/chart-b
 	-	[Scatterplot](#scatterplot)
 	-	[Bubbleplot](#bubbleplot)
     -	[Waffle chart](#waffle-chart)
+    -	[Sparkline chart](#sparkline-chart)
 	-	[Responsive HTML Table](#responsive-html-table) (TODO)
 	-	[Block Histogram](#block-histogram) (TODO)
 	-	[USA State Grid Map](#usa-state-grid-map) (TODO)
@@ -246,7 +247,7 @@ Approximate number of ticks to show on the Y axis.
 
 > Default: `5`
 
-### tickValuesX
+#### tickValuesX
 
 > Default: null
 
@@ -455,6 +456,10 @@ Same as Scatterplot - doesn't take Z axis data into account
 #### suffixZ
 
 ### Waffle chart
+
+New chart type.
+
+### Sparkline chart
 
 New chart type.
 

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Same as Scatterplot - doesn't take Z axis data into account
 
 ### Waffle chart
 
-A 10 x 10 square chart where each square represents approximately 1% of the data. Standard colour themes apply.
+A 10 x 10 square chart where each square represents approximately 1% of the data. Think of it as a square shaped pie chart with better readability. Standard colour themes apply.
 
 #### maxWidth
 > Defaults to `420px` when not on mobile. If this is set too high the chart may appear very large on Desktop.
@@ -467,7 +467,18 @@ A 10 x 10 square chart where each square represents approximately 1% of the data
 
 ### Sparkline chart
 
-New chart type.
+Multiple small lines stacked against each other with minimum and maximum points marked and final data point marked. Minimum and maximum and final data values are also displayed.
+
+#### decimalPlaces
+> Ensure a certain number of decimal places. Rounds to nearest decimal and also appends zeros if needed. Useful for currency.
+
+#### valuePrefix & valueSuffix
+> Symbols etc to put before or after data eg. `$` or `%`
+
+#### fullWidth
+> If set to `off` the sparklines will be arranged into columns on Desktop. If set to `on` the sparklines will stretch to fill the full width of the frame.
+
+Other self-explanatory options include `labelWidth`, `dataLabelWidth`, `chartHeight`
 
 ### Responsive HTML Table
 

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ A 10 x 10 square chart where each square represents approximately 1% of the data
 > Set label width to the width of your longest label. Set a sensible margin between the labels and the chart. Defaults: `85px` & `6px`
 
 #### alignCenter
-> Default to `off`. If set to `on` the waffle chart will center aligned on Desktop and Fluid views.
+> Defaults to `off`. If set to `on` the waffle chart will center aligned on Desktop and Fluid views.
 
 ### Sparkline chart
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project is used with the [Chart Builder](https://github.com/abcnews/chart-b
 	-	[Pie Chart](#pie-chart)
 	-	[Scatterplot](#scatterplot)
 	-	[Bubbleplot](#bubbleplot)
+    -	[Waffle chart](#waffle-chart)
 	-	[Responsive HTML Table](#responsive-html-table) (TODO)
 	-	[Block Histogram](#block-histogram) (TODO)
 	-	[USA State Grid Map](#usa-state-grid-map) (TODO)
@@ -450,6 +451,10 @@ Same as Scatterplot - doesn't take Z axis data into account
 #### prefixZ
 
 #### suffixZ
+
+### Waffle chart
+
+New chart type.
 
 ### Responsive HTML Table
 

--- a/README.md
+++ b/README.md
@@ -457,7 +457,13 @@ Same as Scatterplot - doesn't take Z axis data into account
 
 ### Waffle chart
 
-New chart type.
+A 10 x 10 square chart where each square represents approximately 1% of the data. Standard colour themes apply.
+
+#### maxWidth
+> Defaults to `420px` when not on mobile. If this is set too high the chart may appear very large on Desktop.
+
+#### labelWidth & labelMargin
+> Set label width to the width of your longest label. Set a sensible margin between the labels and the chart. Defaults: `85px` & `6px`
 
 ### Sparkline chart
 


### PR DESCRIPTION
I've added some documentation for the Sparkline Chart and the Waffle Chart types. I've also fixed some hash section linking bugs. Maybe sometime down the track a full documentation clean up might help with readability etc.