### PR TITLE
Center align only if set in data

### DIFF
--- a/graphic_templates/waffle_chart/css/graphic.less
+++ b/graphic_templates/waffle_chart/css/graphic.less
@@ -5,7 +5,6 @@ svg.pattern {
     position: absolute;
 }
 
-
 tspan.value {
     font-weight: bold;
 }
@@ -42,6 +41,10 @@ ul.labels {
     position: absolute;
     z-index: 10;
     visibility: hidden;
+}
+
+.align-center {
+    margin: auto;
 }
 
 @media screen and (min-width: 500px) {

--- a/graphic_templates/waffle_chart/css/graphic.less
+++ b/graphic_templates/waffle_chart/css/graphic.less
@@ -1,10 +1,6 @@
 @import "base";
 @import "labels";
 
-#waffle-chart {
-    margin: auto;
-}
-
 svg.pattern {
     position: absolute;
 }

--- a/graphic_templates/waffle_chart/js/graphic.js
+++ b/graphic_templates/waffle_chart/js/graphic.js
@@ -66,7 +66,7 @@ var renderWaffleChart = function () {
     containerElement.html('');
 
     // Center align if alignCenter is set
-    if (LABELS.alignCenter === 'on') containerElement.style('margin', 'auto');
+    if (LABELS.alignCenter === 'on') containerElement.classed('align-center', true);
 
     /*
      * Create the root SVG element.

--- a/graphic_templates/waffle_chart/js/graphic.js
+++ b/graphic_templates/waffle_chart/js/graphic.js
@@ -66,9 +66,7 @@ var renderWaffleChart = function () {
     containerElement.html('');
 
     // Center align if alignCenter is set
-    if (LABELS.alignCenter === 'on') {
-        containerElement.style('margin', 'auto');
-    }
+    if (LABELS.alignCenter === 'on') containerElement.style('margin', 'auto');
 
     /*
      * Create the root SVG element.

--- a/graphic_templates/waffle_chart/js/graphic.js
+++ b/graphic_templates/waffle_chart/js/graphic.js
@@ -62,7 +62,13 @@ var renderWaffleChart = function () {
     // Clear existing graphic (for redraw)
     var containerElement = d3.select('#waffle-chart')
         .style('max-width', (parseInt(LABELS.maxWidth) || 420) + 'px' )
+
     containerElement.html('');
+
+    // Center align if alignCenter is set
+    if (LABELS.alignCenter === 'on') {
+        containerElement.style('margin', 'auto');
+    }
 
     /*
      * Create the root SVG element.


### PR DESCRIPTION
Adding the option to center the waffle chart if desired. Defaults to left aligned on Desktop and Fluid which seems cleaner.