### PR TITLE
Tick labels in line charts ability to hide in mobile view

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,15 @@ Approximate number of ticks to show on the Y axis.
 
 #### tickValuesX
 
-> Default: null
+> Accepts a comma separated list of text values. Default: null
 
-The values to use for ticks on ordinal (non-date based) charts.
+The values to show for ticks on ordinal (non-date based) charts. Values not in this list will not show up on the X Axis at the bottom of the chart.
+
+#### mobileTickValuesX
+
+> Accepts a comma separated list of text values. Default: null
+
+Only show these values as tick labels on mobile view for "x labeled" ordinal charts (non-date based). Other values will be hidden to avoid clutter.
 
 #### prefixY
 

--- a/graphic_templates/line_chart/js/graphic.js
+++ b/graphic_templates/line_chart/js/graphic.js
@@ -272,6 +272,11 @@ var renderLineChart = function () {
         .tickValues(LABELS.tickValuesX ? LABELS.tickValuesX.split(',').map(function(d) {return +d;}) : null)
         .outerTickSize(0);
 
+    // Show certain values on mobile view
+    if (isMobile && LABELS.mobileTickValuesX) {
+        xAxis.tickValues(LABELS.mobileTickValuesX.split(',').map(function(d) {return +d;}));
+    }
+
     var yAxis = d3.svg.axis()
         .scale(yScale)
         .orient('left')

--- a/graphic_templates/line_chart/js/graphic.js
+++ b/graphic_templates/line_chart/js/graphic.js
@@ -269,12 +269,12 @@ var renderLineChart = function () {
         .orient('bottom')
         .ticks(ticksX)
         .tickFormat(xFormat)
-        .tickValues(LABELS.tickValuesX ? LABELS.tickValuesX.split(',').map(function(d) {return d;}) : null)
+        .tickValues(LABELS.tickValuesX ? LABELS.tickValuesX.split(/\s*,\s*/).map(function(d) {return d;}) : null)
         .outerTickSize(0);
 
     // Show certain values on mobile view
     if (isMobile && LABELS.mobileTickValuesX) {
-        xAxis.tickValues(LABELS.mobileTickValuesX.split(',').map(function(d) {return d;}));
+        xAxis.tickValues(LABELS.mobileTickValuesX.split(/\s*,\s*/).map(function(d) {return d;}));
     }
 
     var yAxis = d3.svg.axis()

--- a/graphic_templates/line_chart/js/graphic.js
+++ b/graphic_templates/line_chart/js/graphic.js
@@ -220,7 +220,7 @@ var renderLineChart = function () {
             .range([0, chartWidth]);
     } else {
         xFormat = function (d, i) {
-            return d;
+            return d.toString();
         };
 
         xScale = d3.scale.ordinal()
@@ -269,12 +269,12 @@ var renderLineChart = function () {
         .orient('bottom')
         .ticks(ticksX)
         .tickFormat(xFormat)
-        .tickValues(LABELS.tickValuesX ? LABELS.tickValuesX.split(',').map(function(d) {return +d;}) : null)
+        .tickValues(LABELS.tickValuesX ? LABELS.tickValuesX.split(',').map(function(d) {return d;}) : null)
         .outerTickSize(0);
 
     // Show certain values on mobile view
     if (isMobile && LABELS.mobileTickValuesX) {
-        xAxis.tickValues(LABELS.mobileTickValuesX.split(',').map(function(d) {return +d;}));
+        xAxis.tickValues(LABELS.mobileTickValuesX.split(',').map(function(d) {return d;}));
     }
 
     var yAxis = d3.svg.axis()


### PR DESCRIPTION
In response to Catherine's bug #82 I've put together this solution, which will let people select which tick labels they want to see on mobile view and thus eliminating the clutter and bunching up we see when there are too many x values.

Once this feature is implemented in the code I will update the Google Doc template.